### PR TITLE
Add dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npx pg-migrate <command> [options]
 
 - `migration:create <name> --path=<folder>` – create a timestamped migration file. The `--path` option is optional when the path is defined in `pg-migration.json`.
 - `migration:up --path=<folder>` – apply all pending migrations.
+- `migration:dry-run --path=<folder>` – run migrations in a transaction and roll back for validation.
 - `migration:down --file=<filename.sql> --path=<folder>` – roll back a single migration.
 - `schema:dump --output=schema.sql` – export the current database schema using `pg_dump`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,8 @@ const runner = new Runner(folderPath);
       console.log(`Created migration: ${filePath}`);
     } else if (command === 'migration:up') {
       await runner.applyMigrations();
+    } else if (command === 'migration:dry-run') {
+      await runner.dryRunMigrations();
     } else if (command === 'migration:down') {
       const filename = fileArg?.split('=')[1];
       if (!filename) throw new Error('--file=<filename> is required');
@@ -81,7 +83,7 @@ const runner = new Runner(folderPath);
       console.log(`Schema dumped to ${output}`);
     } else {
       console.log(
-        'Usage:\n  migration:create <name> --path=./migrations\n  migration:up --path=./migrations\n  migration:down --file=filename.sql --path=./migrations\n  schema:dump --output=schema.sql',
+        'Usage:\n  migration:create <name> --path=./migrations\n  migration:up --path=./migrations\n  migration:dry-run --path=./migrations\n  migration:down --file=filename.sql --path=./migrations\n  schema:dump --output=schema.sql',
       );
     }
   } catch (err) {

--- a/test/runner.spec.ts
+++ b/test/runner.spec.ts
@@ -75,4 +75,10 @@ describe('Migration Runner', () => {
       ['20250101_test.sql']
     );
   });
+
+  it('dry runs migrations', async () => {
+    await expect(runner.dryRunMigrations()).resolves.not.toThrow();
+    expect(postgres.query).toHaveBeenCalledWith('BEGIN');
+    expect(postgres.query).toHaveBeenCalledWith('ROLLBACK');
+  });
 });


### PR DESCRIPTION
## Summary
- add `dryRunMigrations` method to run migrations in a transaction and roll it back
- expose new command `migration:dry-run`
- document dry run in README
- test the new command

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c31761a988327b519968a981492ca