### PR TITLE
Ensure CLI closes Postgres connection after migrations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,8 +9,24 @@ const client = new Client({
   ssl: process.env.PG_USE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
 });
 
-client.connect();
+let connected = false;
+
+const ensureConnected = async () => {
+  if (!connected) {
+    await client.connect();
+    connected = true;
+  }
+};
 
 export const postgres = {
-  query: (text: string, params?: any[]) => client.query(text, params),
+  query: async (text: string, params?: any[]) => {
+    await ensureConnected();
+    return client.query(text, params);
+  },
+  close: async () => {
+    if (connected) {
+      await client.end();
+      connected = false;
+    }
+  },
 };


### PR DESCRIPTION
## Summary
- lazily connect to Postgres and expose a close helper to release resources
- ensure the CLI closes the database connection and avoids forcing process exits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d898dbc6448327a051492a3b230179