### PR TITLE
Publish releases to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -15,7 +18,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org/"
+          registry-url: https://npm.pkg.github.com
+          scope: "@aragornhq"
+          always-auth: true
 
       - name: Set version from tag name
         run: |
@@ -26,7 +31,7 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - name: Publish to NPM
+      - name: Publish to GitHub Packages
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update release workflow to authenticate against GitHub Packages and use the scoped registry
- grant required permissions and always-auth configuration for publishing

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b8ca8e8cc8327a12edaae27cce1d6)