### PR TITLE
Update release workflow to publish to npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://npm.pkg.github.com
-          scope: "@aragornhq"
+          registry-url: https://registry.npmjs.org
           always-auth: true
 
       - name: Set version from tag name
@@ -31,7 +30,7 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - name: Publish to GitHub Packages
+      - name: Publish to npm
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- update release workflow to target the public npm registry
- use NPM_TOKEN for authentication when publishing

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c0862db848327b40ec28d1cdbce7f)