### PR TITLE
Update npm publish registry to npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary
- update publishConfig registry to use the public npmjs.org registry instead of GitHub Packages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c0cd8860083278aa6fae1aac7a88b)