### PR TITLE
Support required PostgreSQL SSL modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ PG_PASSWORD=password
 PG_USE_SSL=false
 ```
 
+Set `PG_USE_SSL=true` (or `1` / `require`) for hosted PostgreSQL providers that require encrypted connections. If PostgreSQL reports `no pg_hba.conf entry ... SSL off`, SSL is required for that connection and this variable should be enabled.
+
+
 2. Specify where your migration files live via a `pg-migration.json` file:
 
 ```json

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,22 @@
 import { Client } from 'pg';
 
+const getSslConfig = () => {
+  const value = process.env.PG_USE_SSL?.toLowerCase();
+
+  if (value === 'true' || value === '1' || value === 'require') {
+    return { rejectUnauthorized: false };
+  }
+
+  return undefined;
+};
+
 const client = new Client({
   host: process.env.PG_HOST,
   port: parseInt(process.env.PG_PORT || '5432', 10),
   database: process.env.PG_DB,
   user: process.env.PG_USER,
   password: process.env.PG_PASSWORD,
-  ssl: process.env.PG_USE_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+  ssl: getSslConfig(),
 });
 
 let connected = false;

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,0 +1,35 @@
+describe('postgres client SSL configuration', () => {
+  const OLD_ENV = process.env;
+  const mockClient = jest.fn();
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    mockClient.mockReset();
+    jest.doMock('pg', () => ({
+      Client: mockClient,
+    }));
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it.each(['true', '1', 'require'])('enables SSL when PG_USE_SSL=%s', (value) => {
+    process.env.PG_USE_SSL = value;
+
+    require('../src/client');
+
+    expect(mockClient).toHaveBeenCalledWith(
+      expect.objectContaining({ ssl: { rejectUnauthorized: false } }),
+    );
+  });
+
+  it('leaves SSL disabled when PG_USE_SSL is false', () => {
+    process.env.PG_USE_SSL = 'false';
+
+    require('../src/client');
+
+    expect(mockClient).toHaveBeenCalledWith(expect.objectContaining({ ssl: undefined }));
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent accidental non-SSL connections to hosted PostgreSQL instances that require encryption, which can produce errors like `no pg_hba.conf entry ... SSL off`.
- Make the SSL toggle more flexible so common truthy values from environment variables are accepted.

### Description
- Add a `getSslConfig` helper in `src/client.ts` and use it for the `ssl` client option so `PG_USE_SSL` accepts `true`, `1`, or `require` (returns `{ rejectUnauthorized: false }`) and leaves SSL `undefined` for `false`.
- Add unit tests in `test/client.spec.ts` that mock `pg.Client` and verify SSL is enabled for `PG_USE_SSL='true'`, `'1'`, and `'require'` and disabled for `'false'`.
- Update `README.md` to document enabling `PG_USE_SSL` and to explain that the `no pg_hba.conf entry ... SSL off` error indicates SSL must be used.

### Testing
- Ran `npm test -- --runInBand`, all test suites passed (`2` suites, `7` tests, all green).
- Ran `npm run build` (`tsc`) and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4a96662db883279c36128c49a06b0c)